### PR TITLE
Add wrapper for heni bootloader programmer

### DIFF
--- a/nesc/whip6/platforms/boards/cc26xxbased/build.spec
+++ b/nesc/whip6/platforms/boards/cc26xxbased/build.spec
@@ -4,7 +4,7 @@
 # Copyright (c) 2012-2016 InviNets Sp z o.o.
 # All rights reserved.
 #
-# This file is distributed under the terms in the attached LICENSE     
+# This file is distributed under the terms in the attached LICENSE
 # files. If you do not find these files, copies can be found by writing
 # to technology@invinets.com.
 #
@@ -56,6 +56,7 @@ dependencies:
   - platforms/tools/programmer/ccbsl
   - platforms/tools/programmer/whipprog
   - platforms/tools/programmer/mesh
+  - platforms/tools/programmer/heni-bl
   - platforms/tools/debugger/ti-checkjtag
   - platforms/tools/debugger/ti-gdbserver
   - platforms/boards/cc26xxbased/private
@@ -82,6 +83,11 @@ composite targets:
   whipinstall:
     - build
     - progwhip
+  henireinstall:
+    - progheni-bl
+  heniinstall:
+    - build
+    - progheni-bl
   build:
     - clean
     - create_build_dir

--- a/nesc/whip6/platforms/tools/programmer/heni-bl/build.spec
+++ b/nesc/whip6/platforms/tools/programmer/heni-bl/build.spec
@@ -1,0 +1,2 @@
+direct targets:
+  - progheni-bl

--- a/nesc/whip6/platforms/tools/programmer/heni-bl/progheni-bl.py
+++ b/nesc/whip6/platforms/tools/programmer/heni-bl/progheni-bl.py
@@ -1,0 +1,17 @@
+import os
+import os.path
+
+from build_step import BuildStep
+
+class ProgBl(BuildStep):
+  def __init__(self,  project_root, configs, flags):
+    BuildStep.__init__(self,  project_root, configs, flags)
+
+  def run_step(self):
+    self.call('heni-bl',
+            os.path.join(self.build_dir, 'app.workingcopy.hex'),
+            'pc',
+            )
+
+# Exports the BuildStep to make it visible for smake
+BuildStepImpl = ProgBl


### PR DESCRIPTION
To use it, run:
$ smake cc2650dk henireinstall
It expects to find heni-bl somewhere in $PATH.