### PR TITLE
UART: blocking read, async read and async write

### DIFF
--- a/nesc/whip6/apps/AsyncReadDemo/AsyncReadDemoApp.nc
+++ b/nesc/whip6/apps/AsyncReadDemo/AsyncReadDemoApp.nc
@@ -1,0 +1,26 @@
+/**
+ * whip6: Warsaw High-performance IPv6.
+ *
+ * Copyright (c) 2017 Uniwersytet Warszawski
+ * All rights reserved.
+ */
+
+configuration AsyncReadDemoApp {
+}
+
+implementation {
+    components BoardStartupPub, AsyncReadDemoPrv;
+    AsyncReadDemoPrv.Boot -> BoardStartupPub;
+
+    components LedsPub;
+    AsyncReadDemoPrv.Green -> LedsPub.Green;
+    AsyncReadDemoPrv.Orange -> LedsPub.Orange;
+    AsyncReadDemoPrv.Red -> LedsPub.Red;
+    AsyncReadDemoPrv.Yellow -> LedsPub.Yellow;
+
+    components new PlatformTimerMilliPub();
+    AsyncReadDemoPrv.Timer -> PlatformTimerMilliPub;
+
+    components BlockingUART0Pub;
+    AsyncReadDemoPrv.ReadNow -> BlockingUART0Pub;
+}

--- a/nesc/whip6/apps/AsyncReadDemo/AsyncReadDemoPrv.nc
+++ b/nesc/whip6/apps/AsyncReadDemo/AsyncReadDemoPrv.nc
@@ -1,0 +1,62 @@
+/**
+ * whip6: Warsaw High-performance IPv6.
+ *
+ * Copyright (c) 2017 Uniwersytet Warszawski
+ * All rights reserved.
+ */
+
+module AsyncReadDemoPrv {
+    uses interface Boot;
+    uses interface Led as Green;
+    uses interface Led as Orange;
+    uses interface Led as Red;
+    uses interface Led as Yellow;
+    uses interface Timer<TMilli, uint32_t>;
+    uses interface ReadNow<uint8_t>;
+}
+
+implementation {
+    uint8_t m_locVal;
+
+    event void Boot.booted() {
+        call Green.off();
+        call Orange.off();
+        call Red.off();
+        call Yellow.off();
+        m_locVal = 'b';
+        call Timer.startWithTimeoutFromNow(2048);
+    }
+
+    event void Timer.fired() {
+        error_t result;
+
+        result = call ReadNow.read();
+
+        if (result != SUCCESS) {
+            call Red.on();
+        }
+        if (m_locVal == 'a') {
+                atomic {
+                    m_locVal = 'b';
+                    call Yellow.off();
+                }
+        } else {
+                atomic {
+                    m_locVal = 'a';
+                    call Yellow.on();
+                }
+        }
+        call Timer.startWithTimeoutFromLastTrigger(3072);
+    }
+
+    async event void ReadNow.readDone(error_t result, uint8_t val) {
+        if (result == SUCCESS) {
+            call Orange.toggle();
+            if (val == m_locVal) {
+                call Green.toggle();
+            }
+        } else {
+            call Red.on();
+        }
+    }
+}

--- a/nesc/whip6/apps/AsyncReadDemo/README
+++ b/nesc/whip6/apps/AsyncReadDemo/README
@@ -1,0 +1,39 @@
+This application serves the purpose of verifing whether uart is able to read a single byte asynchronously.
+
+Every three seconds the application makes a call to start reading. Immediately afterwards it toggles a value of a local character variable. As soon as the user provides the input, the application compares the received byte with the local variable.
+
+*************
+How to use it
+*************
+1. Install the application.
+2. Start minicom (make sure you have connected minicom correctly to the device).
+3. Reset the board.
+4. If the *yellow* led is on, enter a single 'a' character in the minicom terminal; observe the *orange* led and the *green* one.
+5. Otherwise, if the *yellow* led is off, enter 'b' in the minicom terminal; observe the *orange* led and the *green* one.
+6. Then, try entering multiple characters at once; observe the *orange* led.
+7. Wait for a half of minute and enter multiple characters at once; observe the *orange* led.
+
+****************
+Expected outcome
+****************
+Ad 4., 5.:
+- Every time a user enters the proper character, the *orange* led and the *green* led toggle. If the character does not match the local value, only the *orange* led toggles.
+Ad 6.:
+- The *orange* led should toggle once no matter how many characters are entered during a three-second interval between consecutive calls to uart.
+Ad 7.
+- The *orange* led should toggle once despite the fact that the application made more than one call to uart during a half-minute interval.
+- The *red* led should be on to designate that the uart is busy (it keeps waiting for input after the first call).
+
+**********************
+How to diagnose errors
+**********************
+Ad 4., 5.:
+- The *red* led is on and the *orange* led stop toggling after a single character is entered: make sure the interrupt UART_INT_RX is handled properly in the implementation of AsyncRead.
+- The *red* led is off and the *orange* led does not toggle after characters are entered: make sure the event "readDone" is signalled by the implementation of AsyncRead.
+- The *orange* led toggles but the *green* led does not: uart received a different character than expected.
+Ad 6.:
+- The *orange* led toggles multiple times: the implementation of AsyncRead reads more than one byte after a single call.
+Ad 7.:
+- The *orange* led toggles multiple times and the *red* led is on: AsyncRead reads more than one byte after a single call.
+- The *orange* led toggles multiple times and the *red* led is off: the implementation of AsyncRead "hoards" calls to uart.
+- The *yellow* led toggled only once: most probably, AsyncRead is blocking.

--- a/nesc/whip6/apps/AsyncReadDemo/build.spec
+++ b/nesc/whip6/apps/AsyncReadDemo/build.spec
@@ -1,0 +1,4 @@
+app name: AsyncReadDemoApp
+boards:
+ - cc2650dk
+build dir: $(SPEC_DIR)/build/$(BOARD)

--- a/nesc/whip6/apps/AsyncWriteDemo/AsyncWriteDemoApp.nc
+++ b/nesc/whip6/apps/AsyncWriteDemo/AsyncWriteDemoApp.nc
@@ -1,0 +1,28 @@
+/**
+ * whip6: Warsaw High-performance IPv6.
+ *
+ * Copyright (c) 2017 Uniwersytet Warszawski
+ * All rights reserved.
+ */
+
+configuration AsyncWriteDemoApp {
+}
+
+implementation {
+    components BoardStartupPub, AsyncWriteDemoPrv;
+    AsyncWriteDemoPrv.Boot -> BoardStartupPub;
+
+    components LedsPub;
+    AsyncWriteDemoPrv.Yellow -> LedsPub.Yellow;
+    AsyncWriteDemoPrv.Green -> LedsPub.Green;
+    AsyncWriteDemoPrv.Orange -> LedsPub.Orange;
+    AsyncWriteDemoPrv.Red -> LedsPub.Red;
+
+    components new PlatformTimerMilliPub() as Timer1;
+    components new PlatformTimerMilliPub() as Timer2;
+    AsyncWriteDemoPrv.Timer1 -> Timer1;
+    AsyncWriteDemoPrv.Timer2 -> Timer2;
+
+    components BlockingUART0Pub;
+    AsyncWriteDemoPrv.AsyncWrite -> BlockingUART0Pub;
+}

--- a/nesc/whip6/apps/AsyncWriteDemo/AsyncWriteDemoPrv.nc
+++ b/nesc/whip6/apps/AsyncWriteDemo/AsyncWriteDemoPrv.nc
@@ -1,0 +1,66 @@
+/**
+ * whip6: Warsaw High-performance IPv6.
+ *
+ * Copyright (c) 2017 Uniwersytet Warszawski
+ * All rights reserved.
+ */
+
+module AsyncWriteDemoPrv {
+    uses interface Boot;
+    uses interface Led as Green;
+    uses interface Led as Orange;
+    uses interface Led as Red;
+    uses interface Led as Yellow;
+    uses interface Timer<TMilli, uint32_t> as Timer1;
+    uses interface Timer<TMilli, uint32_t> as Timer2;
+    uses interface AsyncWrite<uint8_t>;
+}
+
+implementation {
+    uint8_t m_val;
+    error_t m_result;
+
+    event void Boot.booted() {
+        call Green.off();
+        call Orange.off();
+        call Red.off();
+        call Yellow.off();
+        m_val = 'a' - 1;
+        call Timer1.startWithTimeoutFromNow(1048);
+    }
+
+    event void Timer1.fired() {
+        m_val += 1;
+        m_result = call AsyncWrite.startWrite(m_val);
+        if (m_result != SUCCESS) {
+            call Orange.on();
+        }
+    }
+
+    event void Timer2.fired() {
+        uint8_t locVal = 'a';
+        m_val += 1;
+
+        call Yellow.on();
+
+        do {
+            do {
+                m_result = call AsyncWrite.startWrite(locVal);
+            } while (m_result != SUCCESS);
+            locVal += 1;
+        } while (locVal <= 'z');
+
+        call Green.on();
+    }
+
+    async event void AsyncWrite.writeDone(error_t result) {
+        if (result != SUCCESS) {
+            call Red.on();
+        }
+        if (m_val < 'z') {
+            call Timer1.startWithTimeoutFromLastTrigger(32);
+        } else if (m_val == 'z') {
+            call Timer2.startWithTimeoutFromNow(1048);
+        }
+    }
+}

--- a/nesc/whip6/apps/AsyncWriteDemo/README
+++ b/nesc/whip6/apps/AsyncWriteDemo/README
@@ -1,0 +1,28 @@
+This application serves the purpose of verifing whether uart is able to write a single byte asynchronously.
+It is a one-shot application which runs in two phases.
+
+In the first phase uart writes consecutive alphabet characters, from 'a' to 'z', one by one, each byte in a separate timer-callback function.
+In the second phase, alphabet characters (from 'a' to 'z') are written within a loop, each byte in a separate iteration.
+
+*************
+How to use it
+*************
+1. Install the application.
+2. Start minicom (make sure you have connected minicom correctly to the device).
+3. Reset the board and observe both: the output printed in the minicom terminal and leds.
+
+****************
+Expected outcome
+****************
+Ad 3.
+- Minicom prints a sequence of alphabet characters (from 'a' to 'z') twice.
+- The *yellow* led and the *green* led are on.
+
+**********************
+How to diagnose errors
+**********************
+- If the *orange* led is on: uart failed to write at least one character during the first phase of the program because it was "busy". Try to increase the interval for the Timer1 (default: 32 ms). If the problem persists then, most probably, it is related to triggering interrupt 'UART_INT_TX'.
+- If the *red* led is on: uart failed to write at least one character properly (as for now there is no validation and the signal always comes with "SUCCESS" argument).
+- Only a single character ('a') is printed and the *orange* led is off - there is a problem with signalling the event "writeDone".
+- The *yellow* led is on, and the *green* one is off - AsyncWrite cannot handle sending bytes one by one without significant time intervals between consecutive instructions.
+- The *orange* led and the *red* led are off, the *yellow* led and the *green* one are on, but some characters are missing - AsyncWrite or uart does not work as expected.

--- a/nesc/whip6/apps/AsyncWriteDemo/build.spec
+++ b/nesc/whip6/apps/AsyncWriteDemo/build.spec
@@ -1,0 +1,4 @@
+app name: AsyncWriteDemoApp
+boards:
+ - cc2650dk
+build dir: $(SPEC_DIR)/build/$(BOARD)

--- a/nesc/whip6/apps/BlockingReadDemo/BlockingReadDemoApp.nc
+++ b/nesc/whip6/apps/BlockingReadDemo/BlockingReadDemoApp.nc
@@ -1,0 +1,25 @@
+/**
+ * whip6: Warsaw High-performance IPv6.
+ *
+ * Copyright (c) 2017 Uniwersytet Warszawski
+ * All rights reserved.
+ */
+
+configuration BlockingReadDemoApp {
+}
+
+implementation {
+    components BoardStartupPub, BlockingReadDemoPrv;
+    BlockingReadDemoPrv.Boot -> BoardStartupPub;
+
+    components LedsPub;
+    BlockingReadDemoPrv.Green -> LedsPub.Green;
+    BlockingReadDemoPrv.Orange -> LedsPub.Orange;
+    BlockingReadDemoPrv.Yellow -> LedsPub.Yellow;
+
+    components new PlatformTimerMilliPub();
+    BlockingReadDemoPrv.Timer -> PlatformTimerMilliPub;
+
+    components BlockingUART0Pub;
+    BlockingReadDemoPrv.BlockingRead -> BlockingUART0Pub;
+}

--- a/nesc/whip6/apps/BlockingReadDemo/BlockingReadDemoPrv.nc
+++ b/nesc/whip6/apps/BlockingReadDemo/BlockingReadDemoPrv.nc
@@ -1,0 +1,38 @@
+/**
+ * whip6: Warsaw High-performance IPv6.
+ *
+ * Copyright (c) 2017 Uniwersytet Warszawski
+ * All rights reserved.
+ */
+
+module BlockingReadDemoPrv {
+    uses interface Boot;
+    uses interface Led as Green;
+    uses interface Led as Orange;
+    uses interface Led as Yellow;
+    uses interface Timer<TMilli, uint32_t>;
+    uses interface BlockingRead<uint8_t>;
+}
+
+implementation {
+   uint8_t m_val;
+
+   event void Boot.booted() {
+        call Green.off();
+        call Orange.off();
+        call Yellow.off();
+        call Timer.startWithTimeoutFromNow(2048);
+   }
+
+   event void Timer.fired() {
+        call Yellow.on();
+        m_val = call BlockingRead.read();
+        if (m_val == 'y') {
+            call Green.toggle();
+        } else {
+            call Orange.toggle();
+        }
+        call Yellow.off();
+        call Timer.startWithTimeoutFromNow(2048);
+   }
+}

--- a/nesc/whip6/apps/BlockingReadDemo/README
+++ b/nesc/whip6/apps/BlockingReadDemo/README
@@ -1,0 +1,29 @@
+This application serves the purpose of verifing whether uart is able to read a single byte in the blocking manner.
+
+Two seconds after powering the board the application makes a call to start reading. When the device awaits a character to be entered by a user, the *yellow* led is on. When the application receives an input byte from a user, the character is compared with 'y'. After two seconds the application makes another call to read and the process is repeated.
+
+*************
+How to use it
+*************
+1. Install the application.
+2. Start minicom (make sure you have connected minicom correctly to the device).
+3. Reset the board.
+4. When the *yellow* led is on, enter 'y' once; observe the *green* led and the *orange* led.
+5. When the *yellow* led is on, enter many characters at once; observe the *green* led and the *orange* led.
+6. When the *yellow* led is on, enter a character other than 'y'; observe the *orange* led.
+7. Enter 'y' when the *yellow* led is off; then, when the *yellow* led is on, enter 'z'; observe the leds.
+8. After the *yellow* led turns on do not enter any characters for 30 seconds; observe the leds.
+
+****************
+Expected outcome
+****************
+Ad 4.:
+- The *green* led toggles.
+Ad 5.:
+- The *green* or *orange* led toggle - depending on the first character of the entered sequence.
+Ad 6.:
+- The *orange* led toggles.
+Ad 7.:
+- The *orange* led toggles.
+Ad 8.
+- No led changes its state.

--- a/nesc/whip6/apps/BlockingReadDemo/build.spec
+++ b/nesc/whip6/apps/BlockingReadDemo/build.spec
@@ -1,0 +1,4 @@
+app name: BlockingReadDemoApp
+boards:
+ - cc2650dk
+build dir: $(SPEC_DIR)/build/$(BOARD)

--- a/nesc/whip6/apps/BlockingWriteDemo/BlockingWriteDemoApp.nc
+++ b/nesc/whip6/apps/BlockingWriteDemo/BlockingWriteDemoApp.nc
@@ -1,0 +1,28 @@
+/**
+ * whip6: Warsaw High-performance IPv6.
+ *
+ * Copyright (c) 2017 Uniwersytet Warszawski
+ * All rights reserved.
+ */
+
+configuration BlockingWriteDemoApp {
+}
+
+implementation {
+   components BoardStartupPub, BlockingWriteDemoPrv;
+   BlockingWriteDemoPrv.Boot -> BoardStartupPub;
+
+   components LedsPub;
+   BlockingWriteDemoPrv.Yellow -> LedsPub.Yellow;
+   BlockingWriteDemoPrv.Green -> LedsPub.Green;
+   BlockingWriteDemoPrv.Orange -> LedsPub.Orange;
+   BlockingWriteDemoPrv.Red -> LedsPub.Red;
+
+   components new PlatformTimerMilliPub() as Timer1;
+   components new PlatformTimerMilliPub() as Timer2;
+   BlockingWriteDemoPrv.Timer1 -> Timer1;
+   BlockingWriteDemoPrv.Timer2 -> Timer2;
+
+   components BlockingUART0Pub;
+   BlockingWriteDemoPrv.BlockingWrite -> BlockingUART0Pub;
+}

--- a/nesc/whip6/apps/BlockingWriteDemo/BlockingWriteDemoPrv.nc
+++ b/nesc/whip6/apps/BlockingWriteDemo/BlockingWriteDemoPrv.nc
@@ -1,0 +1,61 @@
+/**
+ * whip6: Warsaw High-performance IPv6.
+ *
+ * Copyright (c) 2017 Uniwersytet Warszawski
+ * All rights reserved.
+ */
+
+module BlockingWriteDemoPrv {
+    uses interface Boot;
+    uses interface Led as Green;
+    uses interface Led as Orange;
+    uses interface Led as Red;
+    uses interface Led as Yellow;
+    uses interface Timer<TMilli, uint32_t> as Timer1;
+    uses interface Timer<TMilli, uint32_t> as Timer2;
+    uses interface BlockingWrite<uint8_t>;
+}
+
+implementation {
+    uint8_t val;
+    error_t result;
+
+    event void Boot.booted() {
+        call Green.off();
+        call Orange.off();
+        call Red.off();
+        call Yellow.off();
+        val = 'a';
+        call Timer1.startWithTimeoutFromNow(1048);
+   }
+
+   event void Timer1.fired() {
+        call Yellow.on();
+        result = call BlockingWrite.write(val);
+        if (result == SUCCESS) {
+            call Green.toggle();
+        } else {
+            call Red.on();
+        }
+        if (val == 'z') {
+            call Yellow.off();
+            call Timer2.startWithTimeoutFromNow(1048);
+        } else {
+            val = val + 1;
+            call Timer1.startWithTimeoutFromLastTrigger(512);
+        }
+   }
+
+   event void Timer2.fired() {
+        call Orange.on();
+        result = SUCCESS;
+        val = 'a' - 1;
+
+        do {
+            val += 1;
+            result = call BlockingWrite.write(val);
+        } while (val != 'z' && result == SUCCESS);
+
+        call Orange.off();
+   }
+}

--- a/nesc/whip6/apps/BlockingWriteDemo/README
+++ b/nesc/whip6/apps/BlockingWriteDemo/README
@@ -1,0 +1,19 @@
+This application serves the purpose of verifing whether uart is able to write a single byte in the blocking manner.
+It is a one-shot application which runs in two phases.
+
+In the first phase (when the *yellow* led is on) uart writes consecutive alphabet characters, from 'a' to 'z', one by one, each byte in a separate timer-callback function.
+In the second phase (when the *orange* led is on), alphabet characters (from 'a' to 'z') are written within a loop, each byte in a separate iteration.
+
+*************
+How to use it
+*************
+1. Install the application.
+2. Start minicom (make sure you have connected minicom correctly to the device).
+3. Reset the board and observe both: the output printed in the minicom terminal and leds.
+
+****************
+Expected outcome
+****************
+Ad 3.
+- Minicom prints a sequence of alphabet characters (from 'a' to 'z') twice.
+- In the end, all leds are off.

--- a/nesc/whip6/apps/BlockingWriteDemo/build.spec
+++ b/nesc/whip6/apps/BlockingWriteDemo/build.spec
@@ -1,0 +1,4 @@
+app name: BlockingWriteDemoApp
+boards:
+ - cc2650dk
+build dir: $(SPEC_DIR)/build/$(BOARD)

--- a/nesc/whip6/platforms/boards/cc26xxbased/BlockingUART0Pub.nc
+++ b/nesc/whip6/platforms/boards/cc26xxbased/BlockingUART0Pub.nc
@@ -15,11 +15,18 @@
 #endif
 
 configuration BlockingUART0Pub {
+    provides interface BlockingRead<uint8_t>;
+    provides interface ReadNow<uint8_t>;
     provides interface BlockingWrite<uint8_t>;
+    provides interface AsyncWrite<uint8_t>;
 }
+
 implementation {
     components new HalBlockingUART0Pub(PLATFORM_UART_BAUD_RATE);
+    BlockingRead = HalBlockingUART0Pub;
+    ReadNow = HalBlockingUART0Pub;
     BlockingWrite = HalBlockingUART0Pub;
+    AsyncWrite = HalBlockingUART0Pub;
 
     components BoardStartupPub;
     BoardStartupPub.InitSequence[0] -> HalBlockingUART0Pub.Init;

--- a/nesc/whip6/platforms/parts/mcu/cc26xx/uart/HalBlockingUART0Pub.nc
+++ b/nesc/whip6/platforms/parts/mcu/cc26xx/uart/HalBlockingUART0Pub.nc
@@ -28,7 +28,9 @@ generic configuration HalBlockingUART0Pub(
     {
         interface Init @exactlyonce();
         interface BlockingRead<uint8_t>;
+        interface ReadNow<uint8_t>;
         interface BlockingWrite<uint8_t>;
+        interface AsyncWrite<uint8_t>;
     }
 }
 implementation {
@@ -39,7 +41,9 @@ implementation {
 
     Init = GenericUartPrv.Init;
     BlockingRead = GenericUartPrv.BlockingRead;
+    ReadNow = GenericUartPrv.ReadNow;
     BlockingWrite = GenericUartPrv.BlockingWrite;
+    AsyncWrite = GenericUartPrv.AsyncWrite;
 
     GenericUartPrv.Interrupt -> Ints.UART0Interrupt;
     GenericUartPrv.PowerDomain -> PowerDomains.SerialDomain;

--- a/nesc/whip6/platforms/parts/mcu/cc26xx/uart/HalBlockingUARTXPrv.nc
+++ b/nesc/whip6/platforms/parts/mcu/cc26xx/uart/HalBlockingUARTXPrv.nc
@@ -28,8 +28,11 @@ generic configuration HalBlockingUARTXPrv(
     {
         interface Init @exactlyonce();
         interface BlockingRead<uint8_t>;
+        interface ReadNow<uint8_t>;
         interface BlockingWrite<uint8_t>;
+        interface AsyncWrite<uint8_t>;
     }
+
     uses
     {
         interface CC26xxPin as RXPin;
@@ -45,7 +48,9 @@ implementation
     components new HalConfigureUARTPrv(uartBase, baud, FALSE) as CfgPrv;
 
     components new HalUARTBlockingReadPrv(uartBase) as UARTReadPrv;
+    components new HalUARTReadNowPrv(uartBase) as UARTReadNowPrv;
     components new HalUARTBlockingWritePrv(uartBase) as UARTWritePrv;
+    components new HalUARTAsyncWritePrv(uartBase) as UARTAsyncWritePrv;
 
     CfgPrv.PowerDomain = PowerDomain;
     CfgPrv.RXPin = RXPin;
@@ -56,11 +61,17 @@ implementation
     CfgPrv.ReInitRegisters <- HalCC26xxSleepPub.AtomicAfterDeepSleepInit;
 
     components new HalAskBeforeSleepPub();
+    UARTReadNowPrv.AskBeforeSleep -> HalAskBeforeSleepPub;
     UARTWritePrv.AskBeforeSleep -> HalAskBeforeSleepPub;
+    UARTAsyncWritePrv.AskBeforeSleep -> HalAskBeforeSleepPub;
 
     Init = CfgPrv.Init;
     BlockingRead = UARTReadPrv;
+    ReadNow = UARTReadNowPrv;
     BlockingWrite = UARTWritePrv;
+    AsyncWrite = UARTAsyncWritePrv;
 
+    Interrupt = UARTReadNowPrv.Interrupt;
     Interrupt = UARTWritePrv.Interrupt;
+    Interrupt = UARTAsyncWritePrv.Interrupt;
 }

--- a/nesc/whip6/platforms/parts/mcu/cc26xx/uart/HalConfigureUARTPrv.nc
+++ b/nesc/whip6/platforms/parts/mcu/cc26xx/uart/HalConfigureUARTPrv.nc
@@ -53,6 +53,7 @@ implementation {
     command error_t ReInitRegisters.init() {
         UARTConfigSetExpClk(uartBase, SysCtrlClockGet(), baud,
                 UART_CONFIG_WLEN_8 | UART_CONFIG_PAR_NONE | UART_CONFIG_STOP_ONE);
+        UARTEnable(uartBase);
         if (enableFIFO) {
             UARTFIFOEnable(uartBase);
         } else {
@@ -60,7 +61,6 @@ implementation {
         }
         call Interrupt.clearPending();
         call Interrupt.asyncNotifications(TRUE);
-        UARTEnable(uartBase);
         return SUCCESS;
     }
 

--- a/nesc/whip6/platforms/parts/mcu/cc26xx/uart/HalUARTAsyncWritePrv.nc
+++ b/nesc/whip6/platforms/parts/mcu/cc26xx/uart/HalUARTAsyncWritePrv.nc
@@ -18,13 +18,14 @@
  */
 
 #include <stdbool.h>
+#include "Assert.h"
 #include "SleepLevels.h"
 
 generic module HalUARTAsyncWritePrv(uint32_t uartBase) {
     provides interface AsyncWrite<uint8_t>;
 
-    uses interface ExternalEvent as Interrupt;
-    uses interface AskBeforeSleep;
+    uses interface ExternalEvent as Interrupt @exactlyonce();
+    uses interface AskBeforeSleep @exactlyonce();
 }
 
 implementation {
@@ -64,4 +65,6 @@ implementation {
             signal AsyncWrite.writeDone(SUCCESS);
         }
     }
+
+    default async event void AsyncWrite.writeDone(error_t result) { }
 }

--- a/nesc/whip6/platforms/parts/mcu/cc26xx/uart/HalUARTReadNowPrv.nc
+++ b/nesc/whip6/platforms/parts/mcu/cc26xx/uart/HalUARTReadNowPrv.nc
@@ -18,13 +18,14 @@
  */
 
 #include "uart.h"
+#include "Assert.h"
 #include "SleepLevels.h"
 
 generic module HalUARTReadNowPrv(uint32_t uartBase) {
     provides interface ReadNow<uint8_t>;
 
-    uses interface ExternalEvent as Interrupt;
-    uses interface AskBeforeSleep;
+    uses interface ExternalEvent as Interrupt @exactlyonce();
+    uses interface AskBeforeSleep @exactlyonce();
 }
 
 implementation {
@@ -60,6 +61,7 @@ implementation {
             atomic busy = FALSE;
             signal ReadNow.readDone(SUCCESS, (uint8_t)value);
         }
-
     }
+
+    default async event void ReadNow.readDone(error_t result, uint8_t val) { }
 }


### PR DESCRIPTION
Changes:

- disable FIFO mode for UART (by moving the command UARTEnable before UARTFIFOEnable(false))

- wire blocking read, async write and async read to HalBlockingUART (need to rename this component in the future)

Additional applications test single functionalities (blocking and asynchronous reading and writing).
