### PR TITLE
Fix compilation without SC UART.

### DIFF
--- a/nesc/whip6/platforms/boards/cc26xxbased/PutcharProviderPub.nc
+++ b/nesc/whip6/platforms/boards/cc26xxbased/PutcharProviderPub.nc
@@ -27,15 +27,15 @@ implementation {
 #ifdef PLATFORM_NO_PRINTF
     // -- no putchar
     components DummyPutcharProviderPub;
-#elseif PLATFORM_PRINTF_OVER_UART0
-    // -- putchar over UART0
-    components BlockingWritePutcharProviderPub;
-    components BlockingUART0Pub;
-    BlockingWritePutcharProviderPub.BlockingWrite -> BlockingUART0Pub;
-#else
+#elif PLATFORM_PRINTF_OVER_SC_UART
     // -- putchar over Sensor Controller UART
     components NonBlockingWritePutcharProviderPub;
     components NonBlockingSCUARTPub;
     NonBlockingWritePutcharProviderPub.NonBlockingWrite -> NonBlockingSCUARTPub;
+#else
+    // -- putchar over UART0
+    components BlockingWritePutcharProviderPub;
+    components BlockingUART0Pub;
+    BlockingWritePutcharProviderPub.BlockingWrite -> BlockingUART0Pub;
 #endif
 }

--- a/nesc/whip6/platforms/boards/cc26xxbased/cherry-v1/build.spec
+++ b/nesc/whip6/platforms/boards/cc26xxbased/cherry-v1/build.spec
@@ -22,3 +22,6 @@ dependencies:
 
 make options:
   - PLATFORM_CC26XX_BOOTLOADER_DIO=8
+
+define:
+ - PLATFORM_PRINTF_OVER_SC_UART


### PR DESCRIPTION
SC UART was the default option for printf which caused compilation error on platforms other than
cherry-v1. This commit reverses the default to UART0 so that SC UART is only used on cherry-v1 platform.