### PR TITLE
Move `.gpram` section before `.appversion` section.

### DIFF
--- a/nesc/whip6/platforms/parts/mcu/cc26xx/cc26xx.lds
+++ b/nesc/whip6/platforms/parts/mcu/cc26xx/cc26xx.lds
@@ -98,8 +98,19 @@ SECTIONS
     } > SRAM AT > FLASH
     _ldata = LOADADDR(.data);
 
+    .gpram : ALIGN(4)
+    { 
+        _gpram = .;
+        *(.gpram*)
+        _egpram = .;
+    } > GPRAM AT > FLASH
+    _lgpram = LOADADDR(.gpram);
+
     /* This section is replaced by a generated NULL-terminated version string,
-     * see Makefile.main. */
+     * see Makefile.main.
+     *
+     * Put all sections that uses flash memory before `.appversion` section
+     * to avoid overwriting them by the generated version string. */
     .appversion : ALIGN(1)
     {
         KEEP(*(.appversion))
@@ -129,14 +140,6 @@ SECTIONS
         . = . + _Min_Stack_Size;
         . = ALIGN(4);
     } > SRAM
-
-    .gpram : ALIGN(4)
-    { 
-        _gpram = .;
-        *(.gpram*)
-        _egpram = .;
-    } > GPRAM AT > FLASH
-    _lgpram = LOADADDR(.gpram);
 
     .bootloader :
     {


### PR DESCRIPTION
`.appversion` section is resized during build process and thus it may overwrite contents of some next section.

Moving `.gpram` section before `.appversion` section makes the `.gpram` section initialization correct.